### PR TITLE
Docker stop command should not fail `npm start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test",
     "lint": "./node_modules/.bin/eslint *.js",
     "build": "docker build -t cron .",
-    "start": "docker stop ingester && docker run -itd --rm --name ingester cron"
+    "start": "docker stop ingester || echo 'ingester is not currently running' && docker run -itd --rm --name ingester cron"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
if the container isn't running.