### PR TITLE
Retrieve metadata for each file

### DIFF
--- a/src/dropbox.js
+++ b/src/dropbox.js
@@ -23,7 +23,8 @@ const getFiles = async () => {
   }
   const responsePairs = await Promise.all(response.entries.map(async (metadataEntry) => {
     const linkResponse = await dbx.filesGetTemporaryLink({path: metadataEntry.path_lower})
-    return { linkResponse, metadataEntry }
+    const fileMetadata = await dbx.filesGetMetadata({path: metadataEntry.path_lower, include_media_info: true})
+    return { linkResponse, metadataEntry: fileMetadata }
   }))
 
   let contentHashSet = new Set()


### PR DESCRIPTION
since the metadata retrieved from filesListFolder is empty due to recent
API changes.